### PR TITLE
Added support for YAML files

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Build Status](https://travis-ci.org/fephil/metalsmith-metadata-directory.svg?branch=master)](https://travis-ci.org/fephil/metalsmith-metadata-directory)
 [![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg)](https://raw.githubusercontent.com/fephil/metalsmith-metadata-directory/master/LICENSE)
 
-> A Metalsmith plugin to add a directory of JSON files for use as global metadata in templates, partials and pages.
+> A Metalsmith plugin to add a directory of JSON and/or YAML files for use as global metadata in templates, partials and pages.
 
 * Author: [Phil Lennon](https://frontendphil.com)
 * Source: [github.com/fephil/metalsmith-metadata-directory](https://github.com/fephil/metalsmith-metadata-directory)
@@ -18,7 +18,7 @@
 
 ## About
 
-This plugin supports adding directory of `.json` files and makes their contents available to the Metalsmith global metadata without needing to declare multiple files or file names. Subdirectories and multiple files are supported by using a globbing pattern.
+This plugin supports adding directory of `.json` & `.yml` files and makes their contents available to the Metalsmith global metadata without needing to declare multiple files or file names. Subdirectories and multiple files are supported by using a globbing pattern.
 
 ## Installation
 
@@ -36,7 +36,7 @@ Add the plugin to your metalsmith.json file:
 {
   "plugins": {
     "metalsmith-metadata-directory": {
-      "directory": "/src/data/**/*.json"
+      "directory": "/src/data/**/*.json" // or: "/src/data/**/*.yml"
     }
   }
 }
@@ -51,7 +51,9 @@ var metalsmith = require('metalsmith')
 var metadata = require('metalsmith-metadata-directory')
 
 metalsmith.use(metadata({
-  directory: '/src/data/**/*.json'
+  directory: '/src/data/**/*.json',
+  // or for YAML respectively; be sure to use 'yml' as file suffix
+  directory: '/src/data/**/*.yml'
 }));
 ```
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,11 +1,12 @@
-var glob = require('glob')
-var fs = require('fs')
-var path = require('path')
-var async = require('async')
-var debug = require('debug')('metalsmith-metadata-directory')
+var glob = require('glob');
+var fs = require('fs');
+var path = require('path');
+var async = require('async');
+var debug = require('debug')('metalsmith-metadata-directory');
+var yaml = require('./yml');
 
 // Make the plugin available
-module.exports = plugin
+module.exports = plugin;
 
 /**
  * Metalsmith plugin to take a directory of json files
@@ -75,6 +76,7 @@ function plugin (opts) {
       // For each found file
       async.forEach(files, function (file, callback) {
         var fileName = path.basename(file)
+        var suffix = /\.([a-z]+)$/i.exec(fileName);
         var theKey = fileName.replace(/\.[^/.]+$/, '')
         var theContents = fs.readFileSync(file, 'utf8')
 
@@ -88,11 +90,20 @@ function plugin (opts) {
           return done()
         }
 
-        // Check to see if JSON is malformed
-        try {
-          var json = JSON.parse(theContents)
-        } catch (error) {
-          return done(new Error('Malformed data in: ' + fileName))
+        if (suffix && suffix[1] && suffix[1].toLowerCase() === 'yml') {
+          // Okay, we detected a file with 'yml' as suffix, let's try to parse it.
+          try {
+            var json = yaml(theContents);
+          } catch (error) {
+            return done(error);
+          }
+        } else {
+          // Check to see if JSON is malformed
+          try {
+            var json = JSON.parse(theContents)
+          } catch (error) {
+            return done(new Error('Malformed data in: ' + fileName))
+          }
         }
 
         // Debug information

--- a/lib/yml.js
+++ b/lib/yml.js
@@ -1,0 +1,16 @@
+const debug = require('debug')('metalsmith-metadata-directory');
+const yaml = require('js-yaml');
+
+function parseYml(text, filename) {
+  let yml = '';
+  try {
+    yml = yaml.safeLoad(text, {
+      filename: filename || null,
+    })
+  } catch(e) {
+    debug(e.message || e);
+    throw new Error(`Malformed YAML in: ${filename}`);
+  }
+} 
+
+module.exports = parseYml;

--- a/lib/yml.js
+++ b/lib/yml.js
@@ -4,9 +4,16 @@ const yaml = require('js-yaml');
 function parseYml(text, filename) {
   let yml = '';
   try {
+    // Try to safe load YAML file, will parse to JSON on success;
     yml = yaml.safeLoad(text, {
       filename: filename || null,
-    })
+    });
+    // Debug output
+    debug('Parsed YAML:');
+    debug(yml);
+
+    // Returned parsed JSON
+    return yml;
   } catch(e) {
     debug(e.message || e);
     throw new Error(`Malformed YAML in: ${filename}`);

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   "dependencies": {
     "async": "2.1.5",
     "debug": "2.6.3",
-    "glob": "7.1.1"
+    "glob": "7.1.1",
+    "js-yaml": "^3.10.0"
   }
 }

--- a/test/fixtures/yaml-multiple/src/example.yml
+++ b/test/fixtures/yaml-multiple/src/example.yml
@@ -1,0 +1,1 @@
+text: Text from a json file

--- a/test/fixtures/yaml-multiple/src/subdirectory/site.yml
+++ b/test/fixtures/yaml-multiple/src/subdirectory/site.yml
@@ -1,0 +1,1 @@
+url: "http://test.dev"

--- a/test/fixtures/yaml-single/src/example.yml
+++ b/test/fixtures/yaml-single/src/example.yml
@@ -1,0 +1,1 @@
+text: Text from a json file

--- a/test/index.js
+++ b/test/index.js
@@ -17,8 +17,34 @@ it('should read a single JSON file and put into metalsmith.metadata()', function
   })
 })
 
+it('should read a single YAML file and put into metalsmith.metadata()', function (done) {
+  var metalsmith = Metalsmith('test/fixtures/yaml-single').use(metadata({ directory: 'src/**/*.yml' }))
+  metalsmith.build(function(err) {
+    metalsmith.metadata().should.deep.equal({ example: { text: 'Text from a json file' } })
+
+    if (err) {
+      return done(err)
+    }
+
+    done()
+  })
+})
+
 it('should read multiple JSON files and put into metalsmith.metadata()', function (done) {
   var metalsmith = Metalsmith('test/fixtures/json-multiple').use(metadata({ directory: 'test/fixtures/json-multiple/src/**/*.json' }))
+  metalsmith.build(function(err) {
+    metalsmith.metadata().should.deep.equal({ example: { text: 'Text from a json file' }, site: { url: 'http://test.dev' } })
+
+    if (err) {
+      return done(err)
+    }
+
+    done()
+  })
+})
+
+it('should read multiple YAML files and put into metalsmith.metadata()', function (done) {
+  var metalsmith = Metalsmith('test/fixtures/yaml-multiple').use(metadata({ directory: 'test/fixtures/yaml-multiple/src/**/*.yml' }))
   metalsmith.build(function(err) {
     metalsmith.metadata().should.deep.equal({ example: { text: 'Text from a json file' }, site: { url: 'http://test.dev' } })
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -147,6 +147,10 @@ esprima@^3.1.1:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-3.1.3.tgz#fdca51cee6133895e3c88d535ce49dbff62a4633"
 
+esprima@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.0.tgz#4499eddcd1110e0b218bacf2fa7f7f59f55ca804"
+
 extend-shallow@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/extend-shallow/-/extend-shallow-2.0.1.tgz#51af7d614ad9a9f610ea1bafbb989d6b1c56890f"
@@ -251,6 +255,13 @@ is-utf8@~0.2.0:
 is@^3.1.0:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/is/-/is-3.2.1.tgz#d0ac2ad55eb7b0bec926a5266f6c662aaa83dca5"
+
+js-yaml@^3.10.0:
+  version "3.10.0"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.10.0.tgz#2e78441646bd4682e963f22b6e92823c309c62dc"
+  dependencies:
+    argparse "^1.0.7"
+    esprima "^4.0.0"
 
 js-yaml@^3.8.1:
   version "3.8.2"


### PR DESCRIPTION
Now this plugin also supports YAML files using the same pattern.  
YAML files must have *.yml* as file suffix, otherwise the plugin would try to interpret the corresponding files as JSON and the parsing process would result in a fail.

This should fix issue #12 