### PR TITLE
import syntax highlighting in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ $ npm install metalsmith-metadata-directory --save-dev
 
 Add the plugin to your metalsmith.json file:
 
-```json
+```js
 {
   "plugins": {
     "metalsmith-metadata-directory": {


### PR DESCRIPTION
json files don't allow comments so it displays it as read, however you can change the syntax highlighter to javascript which will display it nicer