### PR TITLE
Accept .yml and .yaml metadata files.

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Add the plugin to your metalsmith.json file:
 }
 ```
 
-**NOTE:** .yml file extension is also supported.
+**NOTE:** .yml and .yaml file extensions are also supported.
 
 ### With JavaScript
 
@@ -57,7 +57,7 @@ var metadata = require('metalsmith-metadata-directory')
 
 metalsmith.use(metadata({
   directory: '/src/data/**/*.json',
-  // or for YAML respectively; be sure to use 'yml' as file suffix
+  // or for YAML respectively; be sure to use 'yml' or 'yaml' as file suffix
   directory: '/src/data/**/*.yml'
 }));
 ```

--- a/lib/index.js
+++ b/lib/index.js
@@ -90,10 +90,10 @@ function plugin (opts) {
           return done()
         }
 
-        if (suffix && suffix[1] && suffix[1].toLowerCase() === 'yml') {
-          // Okay, we detected a file with 'yml' as suffix, let's try to parse it.
+        if (suffix && suffix[1] && ['yml', 'yaml'].includes(suffix[1].toLowerCase())) {
+          // Okay, we detected a YAML file, let's try to parse it.
           try {
-            var json = yaml(theContents);
+            var json = yaml(theContents, fileName);
           } catch (error) {
             return done(error);
           }

--- a/test/fixtures/yaml-dot-yaml/src/example.yaml
+++ b/test/fixtures/yaml-dot-yaml/src/example.yaml
@@ -1,0 +1,1 @@
+text: Text from a json file

--- a/test/fixtures/yaml-dot-yaml/src/subdirectory/site.yaml
+++ b/test/fixtures/yaml-dot-yaml/src/subdirectory/site.yaml
@@ -1,0 +1,1 @@
+url: 'http://test.dev'

--- a/test/fixtures/yaml-malformed/src/example.yaml
+++ b/test/fixtures/yaml-malformed/src/example.yaml
@@ -1,0 +1,3 @@
+---
+text: "Text from a YAML file"
+malformed

--- a/test/index.js
+++ b/test/index.js
@@ -54,6 +54,19 @@ it('should read multiple YAML files and put into metalsmith.metadata()', functio
   })
 })
 
+it('should read multiple YAML files with .yaml suffix and put into metalsmith.metadata()', function (done) {
+  var metalsmith = Metalsmith('test/fixtures/yaml-dot-yaml').use(metadata({ directory: 'test/fixtures/yaml-dot-yaml/src/**/*.yaml' }))
+  metalsmith.build(function(err) {
+    metalsmith.metadata().should.deep.equal({ example: { text: 'Text from a json file' }, site: { url: 'http://test.dev' } })
+
+    if (err) {
+      return done(err)
+    }
+
+    done()
+  })
+})
+
 it('should read multiple JSON files, including subdirctories and put into metalsmith.metadata()', function (done) {
   var metalsmith = Metalsmith('test/fixtures/json-subdirectory').use(metadata({ directory: 'test/fixtures/json-subdirectory/src/**/*.json' }))
   metalsmith.build(function(err) {
@@ -64,6 +77,17 @@ it('should read multiple JSON files, including subdirctories and put into metals
     }
 
     done()
+  })
+})
+
+it('should error if a YAML file is malformed', function (done) {
+  var metalsmith = Metalsmith('test/fixtures/yaml-malformed').use(metadata({ directory: 'test/fixtures/yaml-malformed/src/**/*.yaml' }))
+  metalsmith.build(function(err) {
+    errMessage = String(err);
+    err.should.be.an('error')
+    errMessage.should.equal('Error: Malformed YAML in: example.yaml')
+
+    done() // don't return the error to metalsmith
   })
 })
 


### PR DESCRIPTION
- Tolerate .yaml in addition to .yml.
- Update the README to say so.
- Add a test for multiple .yaml files.
- Add a test for malformed YAML.
- Pass the YAML file name to the parsing code so
  the file name is reported if there is an error.