### PR TITLE
Fix issue 17 compatibility with metalsmith watch

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,26 @@ This plugin supports debugging output. To enable, use the following command when
 $ DEBUG=metalsmith-metadata-directory metalsmith
 ```
 
+## Using with metalsmith auto-reload 
+
+This plugin check for duplicate key, as most of auto-reload plugin (like metalsmith-watch) will keep the metadata of the previous executions. The error must be disabled in this case.
+
+A valid usage with metalsmith-watch : 
+```
+metalsmith.use(metadata({
+  directory: '/src/data/**/*.json',
+  returnErrorOnDuplicate: false
+}));
+```
+
+It's homewer recommand to use this parameter in dev mode only. : 
+```
+metalsmith.use(metadata({
+  directory: '/src/data/**/*.json',
+  returnErrorOnDuplicate: false
+}));
+```
+
 ## Licence
 
 MIT

--- a/README.md
+++ b/README.md
@@ -94,13 +94,7 @@ metalsmith.use(metadata({
 }));
 ```
 
-It's homewer recommand to use this parameter in dev mode only. : 
-```
-metalsmith.use(metadata({
-  directory: '/src/data/**/*.json',
-  returnErrorOnDuplicate: false
-}));
-```
+Be aware this configuration is recommand only in dev-mode. The duplicate keys will not be checked otherwise.
 
 ## Licence
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -18,6 +18,10 @@ module.exports = plugin;
 function plugin (opts) {
   opts = opts || {}
   var dir = opts.directory
+  var returnErrorOnDuplicate = true
+  if (opts.returnErrorOnDuplicate !== undefined) {
+    returnErrorOnDuplicate = opts.returnErrorOnDuplicate
+  }
 
   /*
    * Fix for resolving local path
@@ -82,7 +86,11 @@ function plugin (opts) {
 
         // Error if the key already exists (duplicate file name)
         if (theKey in metadata) {
-          return done(new Error('Duplicate file name: ' + fileName))
+          if (returnErrorOnDuplicate) {
+            return done(new Error('Duplicate file name: ' + fileName))
+          } else {
+            return done();
+          }
         }
 
         // Ignore file if it is empty


### PR DESCRIPTION
Hello,

The main problem is the watch (and other metalsmith auto-reload plugin) doesn't cleanup the metadata between run. 

To avoid that, I just avoid to return an error in dev-mode. I am not entirely happy with this workaround, but this is working. 

An another solution can be to keep in the metadata all the files already parsed, but this can be a problem on large project with tons of files.

p.s. this is my first contribution in github, if I have done some mistake like how to link with the issue be free to tell me.